### PR TITLE
Fix example config for "max" in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,5 +65,5 @@ value: 10
 # Optional when specified a valid kind
 # Required when not having a kind
 # Possible format: numbers
-value: 25
+max: 25
 ```


### PR DESCRIPTION
This PR fixes the example config in readme which, when copied, does not render properly.